### PR TITLE
Issue#1 and TabStop of Issue #9

### DIFF
--- a/Sources/ConControls/ConControls.xml
+++ b/Sources/ConControls/ConControls.xml
@@ -546,9 +546,6 @@
         <member name="P:ConControls.Controls.ConsoleWindow.Window">
             <inheritdoc />
         </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.Parent">
-            <inheritdoc />
-        </member>
         <member name="P:ConControls.Controls.ConsoleWindow.Title">
             <inheritdoc />
         </member>
@@ -1813,11 +1810,6 @@
         <member name="P:ConControls.Properties.Resources.Exception_WindowDisposed">
             <summary>
               Sucht eine lokalisierte Zeichenfolge, die The console window used by this control has already been disposed of! ähnelt.
-            </summary>
-        </member>
-        <member name="P:ConControls.Properties.Resources.Exception_WindowHasNoParent">
-            <summary>
-              Sucht eine lokalisierte Zeichenfolge, die A console window does not have a parent! ähnelt.
             </summary>
         </member>
         <member name="P:ConControls.Properties.Resources.Exception_WindowSizeNotSupported">

--- a/Sources/ConControls/ConControls.xml
+++ b/Sources/ConControls/ConControls.xml
@@ -40,6 +40,9 @@
             Raised when the button gets clicked.
             </summary>
         </member>
+        <member name="P:ConControls.Controls.Button.TabStop">
+            <inheritdoc />
+        </member>
         <member name="P:ConControls.Controls.Button.Text">
             <inheritdoc />
         </member>
@@ -561,12 +564,6 @@
         <member name="P:ConControls.Controls.ConsoleWindow.ExitCode">
             <inheritdoc />
         </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.BorderStyle">
-            <inheritdoc />
-        </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.CursorSize">
-            <inheritdoc />
-        </member>
         <member name="P:ConControls.Controls.ConsoleWindow.DefaultForegroundColor">
             <inheritdoc />
         </member>
@@ -607,15 +604,6 @@
             <inheritdoc />
         </member>
         <member name="P:ConControls.Controls.ConsoleWindow.Visible">
-            <inheritdoc />
-        </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.ForegroundColor">
-            <inheritdoc />
-        </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.BackgroundColor">
-            <inheritdoc />
-        </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.BorderColor">
             <inheritdoc />
         </member>
         <member name="P:ConControls.Controls.ConsoleWindow.IsDisposed">
@@ -1674,6 +1662,9 @@
             </summary>
         </member>
         <member name="P:ConControls.Controls.TextControl.CursorVisible">
+            <inheritdoc />
+        </member>
+        <member name="P:ConControls.Controls.TextControl.TabStop">
             <inheritdoc />
         </member>
         <member name="P:ConControls.Controls.TextControl.Text">

--- a/Sources/ConControls/ConControls.xml
+++ b/Sources/ConControls/ConControls.xml
@@ -120,9 +120,40 @@
             The <see cref="P:ConControls.Controls.ConsoleControl.CursorVisible"/> of the control has been changed.
             </summary>
         </member>
+        <member name="P:ConControls.Controls.ConsoleControl.Window">
+            <summary>
+            The <see cref="T:ConControls.Controls.IConsoleWindow"/> that contains this control.
+            </summary>
+        </member>
+        <member name="P:ConControls.Controls.ConsoleControl.Parent">
+            <summary>
+            The parent <see cref="T:ConControls.Controls.ConsoleControl"/> that contains this control.
+            The parent must be contained by the same <see cref="T:ConControls.Controls.IConsoleWindow"/>.
+            If this propery is <c>null</c>, the control is not displayed.
+            </summary>
+            <exception cref="T:System.InvalidOperationException">The parent is not part of the same <see cref="T:ConControls.Controls.IConsoleWindow"/> or this control is the root element of the window..</exception>
+        </member>
+        <member name="P:ConControls.Controls.ConsoleControl.Controls">
+            <summary>
+            The collection of <see cref="T:ConControls.Controls.ConsoleControl"/>s contained by this control.
+            </summary>
+        </member>
         <member name="P:ConControls.Controls.ConsoleControl.Name">
             <summary>
-            The name of this control (merely for debug identification).
+            Gets or sets the name of this control.
+            If this is set to <c>null</c> or an empty or whitespace-only string, the name will
+            be set to the name of the control's type.
+            </summary>
+        </member>
+        <member name="P:ConControls.Controls.ConsoleControl.Tag">
+            <summary>
+            Gets or sets a tag object for this control.
+            </summary>
+        </member>
+        <member name="P:ConControls.Controls.ConsoleControl.DrawingInhibited">
+            <summary>
+            Determines if the control can currently be redrawn, depending on calls to <see cref="M:ConControls.Controls.ConsoleControl.DeferDrawing"/>
+            to this control or its parents.
             </summary>
         </member>
         <member name="P:ConControls.Controls.ConsoleControl.Enabled">
@@ -154,6 +185,11 @@
             Gets or sets a number indicating the control's position in the Tab order.
             </summary>
         </member>
+        <member name="P:ConControls.Controls.ConsoleControl.TabStop">
+            <summary>
+            Gets or sets wether this control will be focused when using the Tab key to step through the window.
+            </summary>
+        </member>
         <member name="P:ConControls.Controls.ConsoleControl.Area">
             <summary>
             The effective total area of the control.
@@ -166,64 +202,6 @@
         </member>
         <member name="P:ConControls.Controls.ConsoleControl.Size">
             <inheritdoc />
-        </member>
-        <member name="P:ConControls.Controls.ConsoleControl.Window">
-            <summary>
-            The <see cref="T:ConControls.Controls.IConsoleWindow"/> that contains this control.
-            </summary>
-        </member>
-        <member name="P:ConControls.Controls.ConsoleControl.Parent">
-            <summary>
-            The parent <see cref="T:ConControls.Controls.ConsoleControl"/> that contains this control.
-            The parent must be contained by the same <see cref="T:ConControls.Controls.IConsoleWindow"/>.
-            If this propery is <c>null</c>, the control is not displayed.
-            </summary>
-            <exception cref="T:System.InvalidOperationException">The parent is not part of the same <see cref="T:ConControls.Controls.IConsoleWindow"/> or this control is the root element of the window..</exception>
-        </member>
-        <member name="P:ConControls.Controls.ConsoleControl.Controls">
-            <summary>
-            The collection of <see cref="T:ConControls.Controls.ConsoleControl"/>s contained by this control.
-            </summary>
-        </member>
-        <member name="P:ConControls.Controls.ConsoleControl.DrawingInhibited">
-            <summary>
-            Determines if the control can currently be redrawn, depending on calls to <see cref="M:ConControls.Controls.ConsoleControl.DeferDrawing"/>
-            to this control or its parents.
-            </summary>
-        </member>
-        <member name="P:ConControls.Controls.ConsoleControl.CursorPosition">
-            <summary>
-            Gets or sets the cursor position for this control in character coordinates of the console
-            screen buffer.
-            </summary>
-            <remarks>
-            This property is only used by the <see cref="T:ConControls.Controls.IConsoleWindow"/> if this control is currently
-            focused.
-            </remarks>
-        </member>
-        <member name="P:ConControls.Controls.ConsoleControl.CursorSize">
-            <summary>
-            Gets or sets the cursor size for this control.
-            </summary>
-            <remarks>
-            <para>
-            This value describes the size of the text cursor. It should be between <c>zero</c> and <c>100</c>.
-            </para>
-            <para>
-            This property is only used by the <see cref="T:ConControls.Controls.IConsoleWindow"/> if this control is
-            currently focused.
-            </para>
-            </remarks>
-        </member>
-        <member name="P:ConControls.Controls.ConsoleControl.CursorVisible">
-            <summary>
-            Gets or sets wether the cursor is visible on this control.
-            screen buffer.
-            </summary>
-            <remarks>
-            This property is only used by the <see cref="T:ConControls.Controls.IConsoleWindow"/> if this control is
-            currently focused.
-            </remarks>
         </member>
         <member name="P:ConControls.Controls.ConsoleControl.ForegroundColor">
             <summary>
@@ -299,10 +277,39 @@
             If this is <c>null</c>, the <see cref="P:ConControls.Controls.ConsoleControl.BorderStyle"/> value will be used.
             </summary>
         </member>
-        <member name="P:ConControls.Controls.ConsoleControl.Tag">
+        <member name="P:ConControls.Controls.ConsoleControl.CursorPosition">
             <summary>
-            Gets or sets a tag object for this control.
+            Gets or sets the cursor position for this control in character coordinates of the console
+            screen buffer.
             </summary>
+            <remarks>
+            This property is only used by the <see cref="T:ConControls.Controls.IConsoleWindow"/> if this control is currently
+            focused.
+            </remarks>
+        </member>
+        <member name="P:ConControls.Controls.ConsoleControl.CursorSize">
+            <summary>
+            Gets or sets the cursor size for this control.
+            </summary>
+            <remarks>
+            <para>
+            This value describes the size of the text cursor. It should be between <c>zero</c> and <c>100</c>.
+            </para>
+            <para>
+            This property is only used by the <see cref="T:ConControls.Controls.IConsoleWindow"/> if this control is
+            currently focused.
+            </para>
+            </remarks>
+        </member>
+        <member name="P:ConControls.Controls.ConsoleControl.CursorVisible">
+            <summary>
+            Gets or sets wether the cursor is visible on this control.
+            screen buffer.
+            </summary>
+            <remarks>
+            This property is only used by the <see cref="T:ConControls.Controls.IConsoleWindow"/> if this control is
+            currently focused.
+            </remarks>
         </member>
         <member name="M:ConControls.Controls.ConsoleControl.#ctor(ConControls.Controls.IConsoleWindow)">
             <summary>
@@ -428,14 +435,24 @@
             </summary>
             <returns>A <see cref="T:System.Drawing.Rectangle"/> representing the client area (in client coordinates) of this control.</returns>
         </member>
+        <member name="M:ConControls.Controls.ConsoleControl.OnParentChanged">
+            <summary>
+            Called when the <see cref="P:ConControls.Controls.ConsoleControl.Parent"/> has changed.
+            </summary>
+        </member>
         <member name="M:ConControls.Controls.ConsoleControl.OnNameChanged">
             <summary>
             Called when the <see cref="P:ConControls.Controls.ConsoleControl.Name"/> has changed.
             </summary>
         </member>
-        <member name="M:ConControls.Controls.ConsoleControl.OnParentChanged">
+        <member name="M:ConControls.Controls.ConsoleControl.OnEnabledChanged">
             <summary>
-            Called when the <see cref="P:ConControls.Controls.ConsoleControl.Parent"/> has changed.
+            Called when the <see cref="P:ConControls.Controls.ConsoleControl.Enabled"/> property of this control has been changed.
+            </summary>
+        </member>
+        <member name="M:ConControls.Controls.ConsoleControl.OnVisibleChanged">
+            <summary>
+            Called when the <see cref="P:ConControls.Controls.ConsoleControl.Visible"/> property of this control has been changed.
             </summary>
         </member>
         <member name="M:ConControls.Controls.ConsoleControl.OnCursorPositionChanged">
@@ -456,16 +473,6 @@
         <member name="M:ConControls.Controls.ConsoleControl.OnFocusedChanged">
             <summary>
             Called when the <see cref="P:ConControls.Controls.ConsoleControl.Focused"/> property of this control has been changed.
-            </summary>
-        </member>
-        <member name="M:ConControls.Controls.ConsoleControl.OnEnabledChanged">
-            <summary>
-            Called when the <see cref="P:ConControls.Controls.ConsoleControl.Enabled"/> property of this control has been changed.
-            </summary>
-        </member>
-        <member name="M:ConControls.Controls.ConsoleControl.OnVisibleChanged">
-            <summary>
-            Called when the <see cref="P:ConControls.Controls.ConsoleControl.Visible"/> property of this control has been changed.
             </summary>
         </member>
         <member name="M:ConControls.Controls.ConsoleControl.OnForegroundColorChanged">
@@ -539,6 +546,9 @@
         <member name="P:ConControls.Controls.ConsoleWindow.Window">
             <inheritdoc />
         </member>
+        <member name="P:ConControls.Controls.ConsoleWindow.Parent">
+            <inheritdoc />
+        </member>
         <member name="P:ConControls.Controls.ConsoleWindow.Title">
             <inheritdoc />
         </member>
@@ -554,19 +564,25 @@
         <member name="P:ConControls.Controls.ConsoleWindow.ExitCode">
             <inheritdoc />
         </member>
+        <member name="P:ConControls.Controls.ConsoleWindow.BorderStyle">
+            <inheritdoc />
+        </member>
         <member name="P:ConControls.Controls.ConsoleWindow.CursorSize">
             <inheritdoc />
         </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.ForegroundColor">
+        <member name="P:ConControls.Controls.ConsoleWindow.DefaultForegroundColor">
             <inheritdoc />
         </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.BackgroundColor">
+        <member name="P:ConControls.Controls.ConsoleWindow.DefaultBackgroundColor">
             <inheritdoc />
         </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.BorderColor">
+        <member name="P:ConControls.Controls.ConsoleWindow.DefaultBorderColor">
             <inheritdoc />
         </member>
-        <member name="P:ConControls.Controls.ConsoleWindow.BorderStyle">
+        <member name="P:ConControls.Controls.ConsoleWindow.DefaultBorderStyle">
+            <inheritdoc />
+        </member>
+        <member name="P:ConControls.Controls.ConsoleWindow.DefaultCursorSize">
             <inheritdoc />
         </member>
         <member name="P:ConControls.Controls.ConsoleWindow.Controls">
@@ -594,6 +610,15 @@
             <inheritdoc />
         </member>
         <member name="P:ConControls.Controls.ConsoleWindow.Visible">
+            <inheritdoc />
+        </member>
+        <member name="P:ConControls.Controls.ConsoleWindow.ForegroundColor">
+            <inheritdoc />
+        </member>
+        <member name="P:ConControls.Controls.ConsoleWindow.BackgroundColor">
+            <inheritdoc />
+        </member>
+        <member name="P:ConControls.Controls.ConsoleWindow.BorderColor">
             <inheritdoc />
         </member>
         <member name="P:ConControls.Controls.ConsoleWindow.IsDisposed">
@@ -1080,28 +1105,28 @@
             The title of the console window.
             </summary>
         </member>
-        <member name="P:ConControls.Controls.IConsoleWindow.CursorSize">
+        <member name="P:ConControls.Controls.IConsoleWindow.DefaultCursorSize">
             <summary>
             Gets or sets the default cursor size to use (0-100) for
             newly created focusable controls.
             </summary>
         </member>
-        <member name="P:ConControls.Controls.IConsoleWindow.ForegroundColor">
+        <member name="P:ConControls.Controls.IConsoleWindow.DefaultForegroundColor">
             <summary>
             Gets or sets the default foreground color.
             </summary>
         </member>
-        <member name="P:ConControls.Controls.IConsoleWindow.BackgroundColor">
+        <member name="P:ConControls.Controls.IConsoleWindow.DefaultBackgroundColor">
             <summary>
             Gets or sets the default background color.
             </summary>
         </member>
-        <member name="P:ConControls.Controls.IConsoleWindow.BorderColor">
+        <member name="P:ConControls.Controls.IConsoleWindow.DefaultBorderColor">
             <summary>
             Gets or sets the default border color.
             </summary>
         </member>
-        <member name="P:ConControls.Controls.IConsoleWindow.BorderStyle">
+        <member name="P:ConControls.Controls.IConsoleWindow.DefaultBorderStyle">
             <summary>
             Gets or sets the default border style.
             </summary>
@@ -1193,6 +1218,14 @@
             The main <see cref="T:ConControls.Controls.IConsoleWindow"/> this <see cref="T:ConControls.Controls.IControlContainer"/> belongs to.
             </summary>
         </member>
+        <member name="P:ConControls.Controls.IControlContainer.Parent">
+            <summary>
+            The parent <see cref="T:ConControls.Controls.ConsoleControl"/> that contains this control.
+            The parent must be contained by the same <see cref="T:ConControls.Controls.IConsoleWindow"/>.
+            If this propery is <c>null</c>, the control is not displayed.
+            </summary>
+            <exception cref="T:System.InvalidOperationException">The parent is not part of the same <see cref="T:ConControls.Controls.IConsoleWindow"/> or this control is the root element of the window..</exception>
+        </member>
         <member name="P:ConControls.Controls.IControlContainer.Location">
             <summary>
             The location of this <see cref="T:ConControls.Controls.IControlContainer"/> in character columns and rows
@@ -1230,6 +1263,50 @@
             <summary>
             Gets wether this control or <see cref="T:ConControls.Controls.IControlContainer"/> is visible.
             </summary>
+        </member>
+        <member name="P:ConControls.Controls.IControlContainer.ForegroundColor">
+            <summary>
+            Gets or sets the <see cref="T:System.ConsoleColor"/> to use for foreground drawings.
+            </summary>
+        </member>
+        <member name="P:ConControls.Controls.IControlContainer.BackgroundColor">
+            <summary>
+            Gets or sets the <see cref="T:System.ConsoleColor"/> to use for the background of this control.
+            </summary>
+            <remarks>
+            <para>If this property is <c>null</c>, the parent's setting (or finally the <see cef="Window"/>'s default setting) will be used.</para>
+            </remarks>
+        </member>
+        <member name="P:ConControls.Controls.IControlContainer.BorderColor">
+            <summary>
+            Gets or sets the <see cref="T:System.ConsoleColor"/> to use for the border of this control.
+            </summary>
+            <remarks>
+            <para>If this property is <c>null</c>, the parent's setting (or finally the <see cef="Window"/>'s default setting) will be used.</para>
+            </remarks>
+        </member>
+        <member name="P:ConControls.Controls.IControlContainer.BorderStyle">
+            <summary>
+            Gets or sets the <see cref="P:ConControls.Controls.IControlContainer.BorderStyle"/> of this control.
+            </summary>
+            <remarks>
+            <para>If this property is <c>null</c>, the parent's setting (or finally the <see cef="Window"/>'s default setting) will be used.</para>
+            </remarks>
+        </member>
+        <member name="P:ConControls.Controls.IControlContainer.CursorSize">
+            <summary>
+            Gets or sets the cursor size for this control.
+            </summary>
+            <remarks>
+            <para>
+            This value describes the size of the text cursor. It should be between <c>zero</c> and <c>100</c>.
+            </para>
+            <para>
+            This property is only used by the <see cref="P:ConControls.Controls.IControlContainer.Window"/> if this control is
+            currently focused.
+            </para>
+            <para>If this property is <c>null</c>, the parent's setting (or finally the <see cef="Window"/>'s default setting) will be used.</para>
+            </remarks>
         </member>
         <member name="M:ConControls.Controls.IControlContainer.DeferDrawing">
             <summary>
@@ -1736,6 +1813,11 @@
         <member name="P:ConControls.Properties.Resources.Exception_WindowDisposed">
             <summary>
               Sucht eine lokalisierte Zeichenfolge, die The console window used by this control has already been disposed of! ähnelt.
+            </summary>
+        </member>
+        <member name="P:ConControls.Properties.Resources.Exception_WindowHasNoParent">
+            <summary>
+              Sucht eine lokalisierte Zeichenfolge, die A console window does not have a parent! ähnelt.
             </summary>
         </member>
         <member name="P:ConControls.Properties.Resources.Exception_WindowSizeNotSupported">

--- a/Sources/ConControls/Controls/Button.cs
+++ b/Sources/ConControls/Controls/Button.cs
@@ -16,10 +16,23 @@ namespace ConControls.Controls {
     /// </summary>
     public sealed class Button : TextControl
     {
+        bool initialTabStop = true;
+
         /// <summary>
         /// Raised when the button gets clicked.
         /// </summary>
         public event EventHandler? Click;
+
+        /// <inheritdoc />
+        public override bool TabStop
+        {
+            get => base.TabStop || initialTabStop;
+            set
+            {
+                initialTabStop = false;
+                base.TabStop = value;
+            }
+        }
 
         /// <inheritdoc />
         public override string Text

--- a/Sources/ConControls/Controls/Button.cs
+++ b/Sources/ConControls/Controls/Button.cs
@@ -58,11 +58,11 @@ namespace ConControls.Controls {
             DisabledBackgroundColor = ConsoleColor.DarkBlue;
             DisabledForegroundColor = ConsoleColor.Gray;
             BorderColor = ConsoleColor.DarkYellow;
-            BorderStyle = BorderStyle.SingleLined;
+            BorderStyle = ConControls.Controls.BorderStyle.SingleLined;
             FocusedBackgroundColor = ConsoleColor.Blue;
             FocusedForegroundColor = ConsoleColor.Yellow;
             FocusedBorderColor = ConsoleColor.Yellow;
-            FocusedBorderStyle = BorderStyle.DoubleLined;
+            FocusedBorderStyle = ConControls.Controls.BorderStyle.DoubleLined;
         }
 
         /// <summary>

--- a/Sources/ConControls/Controls/ConsoleWindow.cs
+++ b/Sources/ConControls/Controls/ConsoleWindow.cs
@@ -54,7 +54,7 @@ namespace ConControls.Controls
         ConsoleColor defaultForegroundColor = ConsoleColor.Gray;
         ConsoleColor defaultBackgroundColor = ConsoleColor.Black;
         ConsoleColor defaultBorderColor = ConsoleColor.Yellow;
-        BorderStyle defaultBorderStyle = ConControls.Controls.BorderStyle.None;
+        BorderStyle defaultBorderStyle = BorderStyle.None;
         int defaultCursorSize;
 
         /// <inheritdoc />
@@ -68,7 +68,6 @@ namespace ConControls.Controls
 
         /// <inheritdoc />
         public IConsoleWindow Window => this;
-        IControlContainer? IControlContainer.Parent => null;
         /// <inheritdoc />
         public string Title
         {
@@ -110,19 +109,6 @@ namespace ConControls.Controls
         public int ExitCode { get; private set; }
 
         /// <inheritdoc />
-        public BorderStyle? BorderStyle
-        {
-            get => DefaultBorderStyle;
-            set => DefaultBorderStyle = value ?? DefaultBorderStyle;
-        }
-        /// <inheritdoc />
-        [ExcludeFromCodeCoverage]
-        public int? CursorSize
-        {
-            get => DefaultCursorSize;
-            set => DefaultCursorSize = value ?? DefaultCursorSize;
-        }
-        /// <inheritdoc />
         public ConsoleColor DefaultForegroundColor
         {
             get => defaultForegroundColor;
@@ -130,6 +116,7 @@ namespace ConControls.Controls
             {
                 lock (SynchronizationLock)
                 {
+                    if (value == defaultForegroundColor) return;
                     defaultForegroundColor = value;
                     Invalidate();
                 }
@@ -143,6 +130,7 @@ namespace ConControls.Controls
             {
                 lock (SynchronizationLock)
                 {
+                    if (value == defaultBackgroundColor) return;
                     defaultBackgroundColor = value;
                     Invalidate();
                 }
@@ -156,6 +144,7 @@ namespace ConControls.Controls
             {
                 lock (SynchronizationLock)
                 {
+                    if (value == defaultBorderColor) return;
                     defaultBorderColor = value;
                     Invalidate();
                 }
@@ -169,6 +158,7 @@ namespace ConControls.Controls
             {
                 lock (SynchronizationLock)
                 {
+                    if (value == defaultBorderStyle) return;
                     defaultBorderStyle = value;
                     Invalidate();
                 }
@@ -182,7 +172,8 @@ namespace ConControls.Controls
             {
                 lock (SynchronizationLock)
                 {
-                    defaultCursorSize= value;
+                    if (value == defaultCursorSize) return;
+                    defaultCursorSize = value;
                     Invalidate();
                 }
             }
@@ -262,24 +253,6 @@ namespace ConControls.Controls
         public bool Enabled => !IsDisposed;
         /// <inheritdoc />
         public bool Visible => !IsDisposed;
-        /// <inheritdoc />
-        public ConsoleColor? ForegroundColor
-        {
-            get => DefaultForegroundColor;
-            set => DefaultForegroundColor = value ?? DefaultForegroundColor;
-        }
-        /// <inheritdoc />
-        public ConsoleColor? BackgroundColor
-        {
-            get => DefaultBackgroundColor;
-            set => DefaultBackgroundColor = value ?? DefaultBackgroundColor;
-        }
-        /// <inheritdoc />
-        public ConsoleColor? BorderColor
-        {
-            get => DefaultBorderColor;
-            set => DefaultBorderColor = value ?? DefaultBorderColor;
-        }
         /// <inheritdoc />
         public bool IsDisposed => isDisposed != 0;
         /// <inheritdoc />
@@ -569,5 +542,31 @@ namespace ConControls.Controls
             return size ?? DefaultCursorSize;
         }
 
+        IControlContainer? IControlContainer.Parent => null;
+        ConsoleColor? IControlContainer.ForegroundColor
+        {
+            get => DefaultForegroundColor;
+            set => DefaultForegroundColor = value ?? DefaultForegroundColor;
+        }
+        ConsoleColor? IControlContainer.BackgroundColor
+        {
+            get => DefaultBackgroundColor;
+            set => DefaultBackgroundColor = value ?? DefaultBackgroundColor;
+        }
+        ConsoleColor? IControlContainer.BorderColor
+        {
+            get => DefaultBorderColor;
+            set => DefaultBorderColor = value ?? DefaultBorderColor;
+        }
+        BorderStyle? IControlContainer.BorderStyle
+        {
+            get => DefaultBorderStyle;
+            set => DefaultBorderStyle = value ?? DefaultBorderStyle;
+        }
+        int? IControlContainer.CursorSize
+        {
+            get => DefaultCursorSize;
+            set => DefaultCursorSize = value ?? DefaultCursorSize;
+        }
     }
 }

--- a/Sources/ConControls/Controls/ConsoleWindow.cs
+++ b/Sources/ConControls/Controls/ConsoleWindow.cs
@@ -55,7 +55,7 @@ namespace ConControls.Controls
         ConsoleColor defaultBackgroundColor = ConsoleColor.Black;
         ConsoleColor defaultBorderColor = ConsoleColor.Yellow;
         BorderStyle defaultBorderStyle = ConControls.Controls.BorderStyle.None;
-        int defaultCursorSize = 1;
+        int defaultCursorSize;
 
         /// <inheritdoc />
         public event EventHandler? AreaChanged;
@@ -68,8 +68,7 @@ namespace ConControls.Controls
 
         /// <inheritdoc />
         public IConsoleWindow Window => this;
-        /// <inheritdoc />
-        public IControlContainer? Parent => throw Exceptions.WindowHasNoParent();
+        IControlContainer? IControlContainer.Parent => null;
         /// <inheritdoc />
         public string Title
         {
@@ -314,7 +313,7 @@ namespace ConControls.Controls
             Controls.ControlCollectionChanged += OnControlCollectionChanged;
 
             (originalCursorVisible, originalCursorSize, _) = this.api.GetCursorInfo(this.consoleController.OutputHandle);
-            DefaultCursorSize = originalCursorSize;
+            defaultCursorSize = originalCursorSize;
             this.api.SetCursorInfo(this.consoleController.OutputHandle, false, DefaultCursorSize, Point.Empty);
 
             Invalidate();

--- a/Sources/ConControls/Controls/IConsoleWindow.cs
+++ b/Sources/ConControls/Controls/IConsoleWindow.cs
@@ -38,23 +38,23 @@ namespace ConControls.Controls
         /// Gets or sets the default cursor size to use (0-100) for
         /// newly created focusable controls.
         /// </summary>
-        int CursorSize { get; set; }
+        int DefaultCursorSize { get; set; }
         /// <summary>
         /// Gets or sets the default foreground color.
         /// </summary>
-        ConsoleColor ForegroundColor { get; set; }
+        ConsoleColor DefaultForegroundColor { get; set; }
         /// <summary>
         /// Gets or sets the default background color.
         /// </summary>
-        ConsoleColor BackgroundColor { get; set; }
+        ConsoleColor DefaultBackgroundColor { get; set; }
         /// <summary>
         /// Gets or sets the default border color.
         /// </summary>
-        ConsoleColor BorderColor { get; set; }
+        ConsoleColor DefaultBorderColor { get; set; }
         /// <summary>
         /// Gets or sets the default border style.
         /// </summary>
-        BorderStyle BorderStyle { get; set; }
+        BorderStyle DefaultBorderStyle { get; set; }
         /// <summary>
         /// Gets or sets the currently focused control on this window.
         /// </summary>

--- a/Sources/ConControls/Controls/IControlContainer.cs
+++ b/Sources/ConControls/Controls/IControlContainer.cs
@@ -18,6 +18,13 @@ namespace ConControls.Controls
         /// </summary>
         IConsoleWindow Window { get; }
         /// <summary>
+        /// The parent <see cref="ConsoleControl"/> that contains this control.
+        /// The parent must be contained by the same <see cref="IConsoleWindow"/>.
+        /// If this propery is <c>null</c>, the control is not displayed.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The parent is not part of the same <see cref="IConsoleWindow"/> or this control is the root element of the window..</exception>
+        IControlContainer? Parent { get; }
+        /// <summary>
         /// The location of this <see cref="IControlContainer"/> in character columns and rows
         /// from the upper left corner of the console screen buffer.
         /// </summary>
@@ -50,6 +57,45 @@ namespace ConControls.Controls
         /// Gets wether this control or <see cref="IControlContainer"/> is visible.
         /// </summary>
         bool Visible { get; }
+        /// <summary>
+        /// Gets or sets the <see cref="ConsoleColor"/> to use for foreground drawings.
+        /// </summary>
+        ConsoleColor? ForegroundColor { get; set; }
+        /// <summary>
+        /// Gets or sets the <see cref="ConsoleColor"/> to use for the background of this control.
+        /// </summary>
+        /// <remarks>
+        /// <para>If this property is <c>null</c>, the parent's setting (or finally the <see cef="Window"/>'s default setting) will be used.</para>
+        /// </remarks>
+        ConsoleColor? BackgroundColor { get; set; }
+        /// <summary>
+        /// Gets or sets the <see cref="ConsoleColor"/> to use for the border of this control.
+        /// </summary>
+        /// <remarks>
+        /// <para>If this property is <c>null</c>, the parent's setting (or finally the <see cef="Window"/>'s default setting) will be used.</para>
+        /// </remarks>
+        ConsoleColor? BorderColor { get; set; }
+        /// <summary>
+        /// Gets or sets the <see cref="BorderStyle"/> of this control.
+        /// </summary>
+        /// <remarks>
+        /// <para>If this property is <c>null</c>, the parent's setting (or finally the <see cef="Window"/>'s default setting) will be used.</para>
+        /// </remarks>
+        BorderStyle? BorderStyle { get; set; }
+        /// <summary>
+        /// Gets or sets the cursor size for this control.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This value describes the size of the text cursor. It should be between <c>zero</c> and <c>100</c>.
+        /// </para>
+        /// <para>
+        /// This property is only used by the <see cref="Window"/> if this control is
+        /// currently focused.
+        /// </para>
+        /// <para>If this property is <c>null</c>, the parent's setting (or finally the <see cef="Window"/>'s default setting) will be used.</para>
+        /// </remarks>
+        int? CursorSize { get; set; }
 
         /// <summary>
         /// Defers any drawing operation until the return value has been disposed of again.

--- a/Sources/ConControls/Controls/TextControl.cs
+++ b/Sources/ConControls/Controls/TextControl.cs
@@ -21,7 +21,7 @@ namespace ConControls.Controls
     {
         readonly IConsoleTextController textController;
 
-        bool caretVisible = true, initCursorVisibility = true;
+        bool caretVisible = true, initCursorVisibility = true, initTabStop = true;
         Point scroll;
         Point caret;
 
@@ -66,6 +66,16 @@ namespace ConControls.Controls
             {
                 initCursorVisibility = false;
                 base.CursorVisible = value;
+            }
+        }
+        /// <inheritdoc />
+        public override bool TabStop
+        {
+            get => base.TabStop || initTabStop;
+            set
+            {
+                initTabStop = false;
+                base.TabStop = value;
             }
         }
 

--- a/Sources/ConControls/Exceptions.cs
+++ b/Sources/ConControls/Exceptions.cs
@@ -37,5 +37,6 @@ namespace ConControls
             new Win32Exception(Resources.Exception_CouldNotCreateScreenBuffer, new Win32Exception(Marshal.GetLastWin32Error()));
         internal static Win32Exception CouldNotSetScreenBuffer() =>
             new Win32Exception(Resources.Exception_CouldNotSetScreenBuffer, new Win32Exception(Marshal.GetLastWin32Error()));
+        internal static InvalidOperationException WindowHasNoParent() => new InvalidOperationException(Resources.Exception_WindowHasNoParent);
     }
 }

--- a/Sources/ConControls/Exceptions.cs
+++ b/Sources/ConControls/Exceptions.cs
@@ -37,6 +37,5 @@ namespace ConControls
             new Win32Exception(Resources.Exception_CouldNotCreateScreenBuffer, new Win32Exception(Marshal.GetLastWin32Error()));
         internal static Win32Exception CouldNotSetScreenBuffer() =>
             new Win32Exception(Resources.Exception_CouldNotSetScreenBuffer, new Win32Exception(Marshal.GetLastWin32Error()));
-        internal static InvalidOperationException WindowHasNoParent() => new InvalidOperationException(Resources.Exception_WindowHasNoParent);
     }
 }

--- a/Sources/ConControls/Properties/Resources.Designer.cs
+++ b/Sources/ConControls/Properties/Resources.Designer.cs
@@ -160,6 +160,15 @@ namespace ConControls.Properties {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die A console window does not have a parent! ähnelt.
+        /// </summary>
+        internal static string Exception_WindowHasNoParent {
+            get {
+                return ResourceManager.GetString("Exception_WindowHasNoParent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Changing the console window&apos;s size is currently not supported! ähnelt.
         /// </summary>
         internal static string Exception_WindowSizeNotSupported {

--- a/Sources/ConControls/Properties/Resources.Designer.cs
+++ b/Sources/ConControls/Properties/Resources.Designer.cs
@@ -160,15 +160,6 @@ namespace ConControls.Properties {
         }
         
         /// <summary>
-        ///   Sucht eine lokalisierte Zeichenfolge, die A console window does not have a parent! ähnelt.
-        /// </summary>
-        internal static string Exception_WindowHasNoParent {
-            get {
-                return ResourceManager.GetString("Exception_WindowHasNoParent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Changing the console window&apos;s size is currently not supported! ähnelt.
         /// </summary>
         internal static string Exception_WindowSizeNotSupported {

--- a/Sources/ConControls/Properties/Resources.resx
+++ b/Sources/ConControls/Properties/Resources.resx
@@ -150,9 +150,6 @@
   <data name="Exception_WindowDisposed" xml:space="preserve">
     <value>The console window used by this control has already been disposed of!</value>
   </data>
-  <data name="Exception_WindowHasNoParent" xml:space="preserve">
-    <value>A console window does not have a parent!</value>
-  </data>
   <data name="Exception_WindowSizeNotSupported" xml:space="preserve">
     <value>Changing the console window's size is currently not supported!</value>
   </data>

--- a/Sources/ConControls/Properties/Resources.resx
+++ b/Sources/ConControls/Properties/Resources.resx
@@ -150,6 +150,9 @@
   <data name="Exception_WindowDisposed" xml:space="preserve">
     <value>The console window used by this control has already been disposed of!</value>
   </data>
+  <data name="Exception_WindowHasNoParent" xml:space="preserve">
+    <value>A console window does not have a parent!</value>
+  </data>
   <data name="Exception_WindowSizeNotSupported" xml:space="preserve">
     <value>Changing the console window's size is currently not supported!</value>
   </data>

--- a/Sources/ConControlsExamples/Examples/ProgressBarExample.cs
+++ b/Sources/ConControlsExamples/Examples/ProgressBarExample.cs
@@ -23,7 +23,7 @@ namespace ConControlsExamples.Examples
             using var window = new ConsoleWindow
             {
                 Title = "ConControls: ProgressBar example", 
-                BackgroundColor = ConsoleColor.Blue,
+                DefaultBackgroundColor = ConsoleColor.Blue,
                 CloseWindowKey = KeyCombination.Escape,
                 SwitchConsoleBuffersKey = KeyCombination.F11
             };

--- a/Sources/ConControlsTests/ConControlsTests.csproj
+++ b/Sources/ConControlsTests/ConControlsTests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="UnitTests\ConsoleApi\ConsoleController\InputEvents.cs" />
     <Compile Include="UnitTests\ConsoleApi\ConsoleController\ConsoleControllerTests.cs" />
     <Compile Include="UnitTests\Controls\Button\CursorVisible.cs" />
+    <Compile Include="UnitTests\Controls\Button\TabStop.cs" />
     <Compile Include="UnitTests\Controls\Button\Text.cs" />
     <Compile Include="UnitTests\Controls\Button\PerformClick.cs" />
     <Compile Include="UnitTests\Controls\Button\MouseEvents.cs" />
@@ -135,6 +136,11 @@
     <Compile Include="UnitTests\Controls\ConsoleControl\NameTests.cs" />
     <Compile Include="UnitTests\Controls\ConsoleControl\ConstructorTests.cs" />
     <Compile Include="UnitTests\Controls\ConsoleControl\ConsoleControlTests.cs" />
+    <Compile Include="UnitTests\Controls\ConsoleWindow\DefaultBackgroundColor.cs" />
+    <Compile Include="UnitTests\Controls\ConsoleWindow\DefaultBorderColor.cs" />
+    <Compile Include="UnitTests\Controls\ConsoleWindow\DefaultBorderStyle.cs" />
+    <Compile Include="UnitTests\Controls\ConsoleWindow\DefaultCursorSize.cs" />
+    <Compile Include="UnitTests\Controls\ConsoleWindow\DefaultForegroundColor.cs" />
     <Compile Include="UnitTests\Controls\ConsoleWindow\WaitForCloseAsync.cs" />
     <Compile Include="UnitTests\Controls\ConsoleWindow\DrawingInhibited.cs" />
     <Compile Include="UnitTests\Controls\ConsoleWindow\FocusedControl.cs" />
@@ -166,6 +172,7 @@
     <Compile Include="UnitTests\Controls\ProgressBar\ProgressChar.cs" />
     <Compile Include="UnitTests\Controls\ProgressBar\Percentage.cs" />
     <Compile Include="UnitTests\Controls\ProgressBar\ProgressBarTests.cs" />
+    <Compile Include="UnitTests\Controls\TextControl\TabStop.cs" />
     <Compile Include="UnitTests\Controls\TextControl\Clear.cs" />
     <Compile Include="UnitTests\Controls\TextControl\CursorPosition.cs" />
     <Compile Include="UnitTests\Controls\TextControl\Wrap.cs" />

--- a/Sources/ConControlsTests/ConControlsTestsCli.cs
+++ b/Sources/ConControlsTests/ConControlsTestsCli.cs
@@ -36,7 +36,7 @@ namespace ConControlsTests
                 {
                     SwitchConsoleBuffersKey = KeyCombination.F11,
                     CloseWindowKey = KeyCombination.AltF4,
-                    BackgroundColor = ConsoleColor.DarkBlue,
+                    DefaultBackgroundColor = ConsoleColor.DarkBlue,
                     Title = "ConControls example"
                 };
                 using(window.DeferDrawing())
@@ -60,7 +60,8 @@ namespace ConControlsTests
                     {
                         Parent = frame,
                         Area = new Rectangle(2, 6, 9, 1),
-                        Text = "Progress:"
+                        Text = "Progress:",
+                        BorderStyle = BorderStyle.None
                     };
                     _ = new ProgressBar(window)
                     {
@@ -75,7 +76,8 @@ namespace ConControlsTests
                     {
                         Parent = frame,
                         Area = new Rectangle(2, 11, 6, 1),
-                        Text = "Output:"
+                        Text = "Output:",
+                        BorderStyle = BorderStyle.None
                     };
                     _ = new TextBlock(window)
                     {

--- a/Sources/ConControlsTests/UnitTests/Controls/Button/TabStop.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Button/TabStop.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * (C) René Vogt
+ *
+ * Published under MIT license as described in the LICENSE.md file.
+ *
+ */
+
+#nullable enable
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ConControlsTests.UnitTests.Controls.Button
+{
+    public partial class ButtonTests
+    {
+        [TestMethod]
+        public void TabStop_InitiallyTrue()
+        {
+            using var stubbedWindow = new StubbedWindow();
+            using var sut = new ConControls.Controls.Button(stubbedWindow);
+            sut.TabStop.Should().BeTrue();
+            sut.TabStop = false;
+            sut.TabStop.Should().BeFalse();
+            sut.TabStop = true;
+            sut.TabStop.Should().BeTrue();
+        }
+    }
+}

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/BackgroundColorTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/BackgroundColorTests.cs
@@ -18,13 +18,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void BackgroundColor_Changed_ThreadSafeHandlerCall()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                BackgroundColorGet = () => ConsoleColor.Cyan
-            };
-
+            using var stubbedWindow = new StubbedWindow();
             var sut = new StubbedConsoleControl(stubbedWindow);
-            sut.BackgroundColor.Should().Be(ConsoleColor.Cyan);
+            sut.BackgroundColor.Should().BeNull();
 
             sut.GetMethodCount(StubbedConsoleControl.MethodOnBackgroundColorChanged).Should().Be(0);
             sut.BackgroundColor = ConsoleColor.DarkMagenta;
@@ -34,16 +30,12 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void BackgroundColor_NotChanged_NoEvent()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                BackgroundColorGet = () => ConsoleColor.Cyan
-            };
+            var stubbedWindow = new StubbedWindow();
 
             var sut = new StubbedConsoleControl(stubbedWindow);
-
             sut.GetMethodCount(StubbedConsoleControl.MethodOnBackgroundColorChanged).Should().Be(0);
             sut.BackgroundColor = sut.BackgroundColor;
-            sut.BackgroundColor.Should().Be(ConsoleColor.Cyan);
+            sut.BackgroundColor.Should().BeNull();
             sut.GetMethodCount(StubbedConsoleControl.MethodOnBackgroundColorChanged).Should().Be(0);
         }
     }

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/BorderColorTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/BorderColorTests.cs
@@ -18,13 +18,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void BorderColor_Changed_ThreadSafeHandlerCall()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                BorderColorGet = () => ConsoleColor.Cyan
-            };
-
+            var stubbedWindow = new StubbedWindow();
             var sut = new StubbedConsoleControl(stubbedWindow);
-            sut.BorderColor.Should().Be(ConsoleColor.Cyan);
+            sut.BorderColor.Should().BeNull();
 
             sut.GetMethodCount(StubbedConsoleControl.MethodOnBorderColorChanged).Should().Be(0);
             sut.BorderColor = ConsoleColor.DarkMagenta;
@@ -34,16 +30,12 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void BorderColor_NotChanged_NoEvent()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                BorderColorGet = () => ConsoleColor.Cyan
-            };
-
+            var stubbedWindow = new StubbedWindow();
             var sut = new StubbedConsoleControl(stubbedWindow);
 
             sut.GetMethodCount(StubbedConsoleControl.MethodOnBorderColorChanged).Should().Be(0);
             sut.BorderColor = sut.BorderColor;
-            sut.BorderColor.Should().Be(ConsoleColor.Cyan);
+            sut.BorderColor.Should().BeNull();
             sut.GetMethodCount(StubbedConsoleControl.MethodOnBorderColorChanged).Should().Be(0);
         }
     }

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/BorderStyleTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/BorderStyleTests.cs
@@ -18,13 +18,10 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void BorderStyle_Changed_ThreadSafeHandlerCall()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                BorderStyleGet = () => BorderStyle.SingleLined
-            };
+            var stubbedWindow = new StubbedWindow();
 
             var sut = new StubbedConsoleControl(stubbedWindow);
-            sut.BorderStyle.Should().Be(BorderStyle.SingleLined);
+            sut.BorderStyle.Should().BeNull();
 
             sut.GetMethodCount(StubbedConsoleControl.MethodOnBorderStyleChanged).Should().Be(0);
             sut.BorderStyle = BorderStyle.DoubleLined;
@@ -34,16 +31,13 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void BorderStyle_NotChanged_NoEvent()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                BorderStyleGet = () => BorderStyle.SingleLined
-            };
+            var stubbedWindow = new StubbedWindow();
 
             var sut = new StubbedConsoleControl(stubbedWindow);
 
             sut.GetMethodCount(StubbedConsoleControl.MethodOnBorderStyleChanged).Should().Be(0);
             sut.BorderStyle = sut.BorderStyle;
-            sut.BorderStyle.Should().Be(BorderStyle.SingleLined);
+            sut.BorderStyle.Should().BeNull();
             sut.GetMethodCount(StubbedConsoleControl.MethodOnBorderStyleChanged).Should().Be(0);
         }
     }

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/ConstructorTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/ConstructorTests.cs
@@ -8,7 +8,6 @@
 #nullable enable
 
 using System;
-using ConControls.Controls;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -26,19 +25,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void ConsoleControl_CompletelyInitialized_NoParentYet()
         {
-            const int cursorSize = 50;
-            const ConsoleColor foreground = ConsoleColor.Magenta;
-            const ConsoleColor background = ConsoleColor.Cyan;
-            const ConsoleColor borderColor = ConsoleColor.DarkMagenta;
-            const BorderStyle borderStyle = BorderStyle.DoubleLined;
             var stubbedWindow = new StubbedWindow
             {
-                VisibleGet = () => true,
-                CursorSizeGet = () => cursorSize,
-                ForegroundColorGet = () => foreground,
-                BackgroundColorGet = () => background,
-                BorderColorGet = () => borderColor,
-                BorderStyleGet = () => borderStyle
+                VisibleGet = () => true
             };
 
             var sut = new StubbedConsoleControl(stubbedWindow);
@@ -46,11 +35,6 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
             sut.Enabled.Should().BeFalse();
             sut.CanFocus.Should().BeFalse();
             sut.Name.Should().Be(nameof(StubbedConsoleControl));
-            sut.CursorSize.Should().Be(cursorSize);
-            sut.ForegroundColor.Should().Be(foreground);
-            sut.BackgroundColor.Should().Be(background);
-            sut.BorderColor.Should().Be(borderColor);
-            sut.BorderStyle.Should().Be(borderStyle);
             sut.Parent.Should().BeNull();
 
             sut.Parent = stubbedWindow;

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/CursorSizeTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/CursorSizeTests.cs
@@ -17,13 +17,10 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void CursorSize_Changed_ThreadSafeHandlerCall()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                CursorSizeGet = () => 12
-            };
+            var stubbedWindow = new StubbedWindow();
 
             var sut = new StubbedConsoleControl(stubbedWindow);
-            sut.CursorSize.Should().Be(12);
+            sut.CursorSize.Should().BeNull();
             bool eventRaised = false;
             sut.CursorSizeChanged += (sender, e) =>
             {
@@ -41,10 +38,7 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void CursorSize_NotChanged_NoEvent()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                CursorSizeGet = () => 12
-            };
+            var stubbedWindow = new StubbedWindow();
 
             var sut = new StubbedConsoleControl(stubbedWindow);
             bool eventRaised = false;
@@ -56,7 +50,7 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
 
             sut.GetMethodCount(StubbedConsoleControl.MethodOnCursorSizeChanged).Should().Be(0);
             sut.CursorSize = sut.CursorSize;
-            sut.CursorSize.Should().Be(12);
+            sut.CursorSize.Should().BeNull();
             sut.GetMethodCount(StubbedConsoleControl.MethodOnCursorSizeChanged).Should().Be(0);
             eventRaised.Should().BeFalse();
         }

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/EffectiveBackgroundColorTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/EffectiveBackgroundColorTests.cs
@@ -21,9 +21,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
             ConControls.Controls.ConsoleControl? focused = null;
             var stubbedWindow = new StubbedWindow
             {
-                ForegroundColorGet = () => ConsoleColor.DarkRed,
-                BackgroundColorGet = () => ConsoleColor.Cyan,
-                BorderColorGet = () => ConsoleColor.DarkYellow,
+                DefaultForegroundColorGet = () => ConsoleColor.DarkRed,
+                DefaultBackgroundColorGet = () => ConsoleColor.Cyan,
+                DefaultBorderColorGet = () => ConsoleColor.DarkYellow,
                 EnabledGet = () => true,
                 FocusedControlGet = () => focused,
                 FocusedControlSetConsoleControl = c => focused = c
@@ -48,9 +48,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
             ConControls.Controls.ConsoleControl? focused = null;
             var stubbedWindow = new StubbedWindow
             {
-                ForegroundColorGet = () => ConsoleColor.DarkRed,
-                BackgroundColorGet = () => ConsoleColor.Cyan,
-                BorderColorGet = () => ConsoleColor.DarkYellow,
+                DefaultForegroundColorGet = () => ConsoleColor.DarkRed,
+                DefaultBackgroundColorGet = () => ConsoleColor.Cyan,
+                DefaultBorderColorGet = () => ConsoleColor.DarkYellow,
                 FocusedControlGet = () => focused,
                 EnabledGet = () => true,
                 FocusedControlSetConsoleControl = c => focused = c

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/EffectiveBorderColorTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/EffectiveBorderColorTests.cs
@@ -22,9 +22,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
             ConControls.Controls.ConsoleControl? focused = null;
             var stubbedWindow = new StubbedWindow
             {
-                ForegroundColorGet = () => ConsoleColor.DarkYellow,
-                BackgroundColorGet = () => ConsoleColor.DarkRed,
-                BorderColorGet = () => ConsoleColor.Cyan,
+                DefaultForegroundColorGet = () => ConsoleColor.DarkYellow,
+                DefaultBackgroundColorGet = () => ConsoleColor.DarkRed,
+                DefaultBorderColorGet = () => ConsoleColor.Cyan,
                 EnabledGet = () => true,
                 GetGraphics = () => new StubIConsoleGraphics(),
                 FocusedControlGet = () => focused,
@@ -50,9 +50,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
             ConControls.Controls.ConsoleControl? focused = null;
             var stubbedWindow = new StubbedWindow
             {
-                ForegroundColorGet = () => ConsoleColor.DarkYellow,
-                BackgroundColorGet = () => ConsoleColor.DarkRed,
-                BorderColorGet = () => ConsoleColor.Cyan,
+                DefaultForegroundColorGet = () => ConsoleColor.DarkYellow,
+                DefaultBackgroundColorGet = () => ConsoleColor.DarkRed,
+                DefaultBorderColorGet = () => ConsoleColor.Cyan,
                 FocusedControlGet = () => focused,
                 EnabledGet = () => true,
                 FocusedControlSetConsoleControl = c => focused = c

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/EffectiveForegroundColorTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/EffectiveForegroundColorTests.cs
@@ -21,9 +21,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
             ConControls.Controls.ConsoleControl? focused = null;
             var stubbedWindow = new StubbedWindow
             {
-                ForegroundColorGet = () => ConsoleColor.Cyan,
-                BackgroundColorGet = () => ConsoleColor.DarkRed,
-                BorderColorGet = () => ConsoleColor.DarkYellow,
+                DefaultForegroundColorGet = () => ConsoleColor.Cyan,
+                DefaultBackgroundColorGet = () => ConsoleColor.DarkRed,
+                DefaultBorderColorGet = () => ConsoleColor.DarkYellow,
                 EnabledGet = () => true,
                 FocusedControlGet = () => focused,
                 FocusedControlSetConsoleControl = c => focused = c
@@ -48,9 +48,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
             ConControls.Controls.ConsoleControl? focused = null;
             var stubbedWindow = new StubbedWindow
             {
-                ForegroundColorGet = () => ConsoleColor.Cyan,
-                BackgroundColorGet = () => ConsoleColor.DarkRed,
-                BorderColorGet = () => ConsoleColor.DarkYellow,
+                DefaultForegroundColorGet = () => ConsoleColor.Cyan,
+                DefaultBackgroundColorGet = () => ConsoleColor.DarkRed,
+                DefaultBorderColorGet = () => ConsoleColor.DarkYellow,
                 FocusedControlGet = () => focused,
                 EnabledGet = () => true,
                 FocusedControlSetConsoleControl = c => focused = c

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/ForegroundColorTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/ForegroundColorTests.cs
@@ -18,13 +18,9 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void ForegroundColor_Changed_ThreadSafeHandlerCall()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                ForegroundColorGet = () => ConsoleColor.Cyan
-            };
-
+            var stubbedWindow = new StubbedWindow();
             var sut = new StubbedConsoleControl(stubbedWindow);
-            sut.ForegroundColor.Should().Be(ConsoleColor.Cyan);
+            sut.ForegroundColor.Should().BeNull();
 
             sut.GetMethodCount(StubbedConsoleControl.MethodOnForegroundColorChanged).Should().Be(0);
             sut.ForegroundColor = ConsoleColor.DarkMagenta;
@@ -34,16 +30,12 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
         [TestMethod]
         public void ForegroundColor_NotChanged_NoEvent()
         {
-            var stubbedWindow = new StubbedWindow
-            {
-                ForegroundColorGet = () => ConsoleColor.Cyan
-            };
-
+            var stubbedWindow = new StubbedWindow();
             var sut = new StubbedConsoleControl(stubbedWindow);
 
             sut.GetMethodCount(StubbedConsoleControl.MethodOnForegroundColorChanged).Should().Be(0);
             sut.ForegroundColor = sut.ForegroundColor;
-            sut.ForegroundColor.Should().Be(ConsoleColor.Cyan);
+            sut.ForegroundColor.Should().BeNull();
             sut.GetMethodCount(StubbedConsoleControl.MethodOnForegroundColorChanged).Should().Be(0);
         }
     }

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/PointToClient.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/PointToClient.cs
@@ -74,8 +74,8 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
             sut2.PointToClient(consolePoint)
                 .Should()
                 .Be(new Point(
-                        consolePoint.X - l1.X - l2.X - 1,
-                        consolePoint.Y - l1.Y - l2.Y - 1));
+                        consolePoint.X - l1.X - l2.X - 2,
+                        consolePoint.Y - l1.Y - l2.Y - 2));
         }
         [TestMethod]
         public void PointToClient_NoParent_CorrectResult()

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/PointToConsole.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleControl/PointToConsole.cs
@@ -75,8 +75,8 @@ namespace ConControlsTests.UnitTests.Controls.ConsoleControl
             sut2.PointToConsole(clientPoint)
                 .Should()
                 .Be(new Point(
-                        clientPoint.X + l1.X + l2.X + 1,
-                        clientPoint.Y + l1.Y + l2.Y + 1));
+                        clientPoint.X + l1.X + l2.X + 2,
+                        clientPoint.Y + l1.Y + l2.Y + 2));
 
         }
         [TestMethod]

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultBackgroundColor.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultBackgroundColor.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * (C) René Vogt
+ *
+ * Published under MIT license as described in the LICENSE.md file.
+ *
+ */
+
+#nullable enable
+
+using System;
+using ConControls.Controls;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+// ReSharper disable AccessToDisposedClosure
+
+namespace ConControlsTests.UnitTests.Controls.ConsoleWindow
+{
+    public partial class ConsoleWindowTests
+    {
+        [TestMethod]
+        public void DefaultBackgroundColor_SetAndDrawn()
+        {
+            const ConsoleColor color = ConsoleColor.DarkMagenta;
+            var api = new StubbedNativeCalls();
+            using var controller = new StubbedConsoleController();
+            bool graphicsProvided = false;
+            var graphicsProvider = new StubbedGraphicsProvider();
+            graphicsProvider.ProvideConsoleOutputHandleINativeCallsSizeFrameCharSets = (handle, calls, arg3, arg4) =>
+            {
+                graphicsProvided = true;
+                return graphicsProvider.Graphics;
+            };
+            using var sut = new ConControls.Controls.ConsoleWindow(api, controller, graphicsProvider);
+            var suti = (IControlContainer)sut;
+            sut.DefaultBackgroundColor.Should().Be(ConsoleColor.Black);
+            suti.BackgroundColor.Should().Be(ConsoleColor.Black);
+            graphicsProvided = false;
+            suti.BackgroundColor = color;
+            graphicsProvided.Should().BeTrue();
+            sut.DefaultBackgroundColor.Should().Be(color);
+
+            graphicsProvided = false;
+            suti.BackgroundColor = null;
+            graphicsProvided.Should().BeFalse();
+            sut.DefaultBackgroundColor.Should().Be(color);
+        }
+    }
+}

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultBorderColor.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultBorderColor.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * (C) René Vogt
+ *
+ * Published under MIT license as described in the LICENSE.md file.
+ *
+ */
+
+#nullable enable
+
+using System;
+using ConControls.Controls;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+// ReSharper disable AccessToDisposedClosure
+
+namespace ConControlsTests.UnitTests.Controls.ConsoleWindow
+{
+    public partial class ConsoleWindowTests
+    {
+        [TestMethod]
+        public void DefaultBorderColor_SetAndDRawn()
+        {
+            const ConsoleColor color = ConsoleColor.DarkMagenta;
+            var api = new StubbedNativeCalls();
+            using var controller = new StubbedConsoleController();
+            bool graphicsProvided = false;
+            var graphicsProvider = new StubbedGraphicsProvider();
+            graphicsProvider.ProvideConsoleOutputHandleINativeCallsSizeFrameCharSets = (handle, calls, arg3, arg4) =>
+            {
+                graphicsProvided = true;
+                return graphicsProvider.Graphics;
+            };
+            using var sut = new ConControls.Controls.ConsoleWindow(api, controller, graphicsProvider);
+            var suti = (IControlContainer)sut;
+            sut.DefaultBorderColor.Should().Be(ConsoleColor.Yellow);
+            suti.BorderColor.Should().Be(ConsoleColor.Yellow);
+            graphicsProvided = false;
+            suti.BorderColor = color;
+            graphicsProvided.Should().BeTrue();
+            sut.DefaultBorderColor.Should().Be(color);
+
+            graphicsProvided = false;
+            suti.BorderColor = null;
+            graphicsProvided.Should().BeFalse();
+            sut.DefaultBorderColor.Should().Be(color);
+        }
+    }
+}

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultBorderStyle.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultBorderStyle.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * (C) René Vogt
+ *
+ * Published under MIT license as described in the LICENSE.md file.
+ *
+ */
+
+#nullable enable
+
+using ConControls.Controls;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+// ReSharper disable AccessToDisposedClosure
+
+namespace ConControlsTests.UnitTests.Controls.ConsoleWindow
+{
+    public partial class ConsoleWindowTests
+    {
+        [TestMethod]
+        public void DefaultBorderStyle_SetAndDrawn()
+        {
+            const BorderStyle style = BorderStyle.Bold;
+            var api = new StubbedNativeCalls();
+            using var controller = new StubbedConsoleController();
+            bool graphicsProvided = false;
+            var graphicsProvider = new StubbedGraphicsProvider();
+            graphicsProvider.ProvideConsoleOutputHandleINativeCallsSizeFrameCharSets = (handle, calls, arg3, arg4) =>
+            {
+                graphicsProvided = true;
+                return graphicsProvider.Graphics;
+            };
+            using var sut = new ConControls.Controls.ConsoleWindow(api, controller, graphicsProvider);
+            var suti = (IControlContainer)sut;
+            sut.DefaultBorderStyle.Should().Be(BorderStyle.None);
+            suti.BorderStyle.Should().Be(BorderStyle.None);
+            graphicsProvided = false;
+            suti.BorderStyle = style;
+            graphicsProvided.Should().BeTrue();
+            sut.DefaultBorderStyle.Should().Be(style);
+
+            graphicsProvided = false;
+            suti.BorderStyle = null;
+            graphicsProvided.Should().BeFalse();
+            sut.DefaultBorderStyle.Should().Be(style);
+        }
+    }
+}

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultCursorSize.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultCursorSize.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * (C) René Vogt
+ *
+ * Published under MIT license as described in the LICENSE.md file.
+ *
+ */
+
+#nullable enable
+
+using System.Drawing;
+using ConControls.Controls;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+// ReSharper disable AccessToDisposedClosure
+
+namespace ConControlsTests.UnitTests.Controls.ConsoleWindow
+{
+    public partial class ConsoleWindowTests
+    {
+        [TestMethod]
+        public void DefaultCursorSize_SetAndDrawn()
+        {
+            const int originalCursorSize = 17;
+            const int alternativeCursorSize = 23;
+            var api = new StubbedNativeCalls
+            {
+                GetCursorInfoConsoleOutputHandle = handle => (true, originalCursorSize, Point.Empty)
+            };
+            using var controller = new StubbedConsoleController();
+            bool graphicsProvided = false;
+            var graphicsProvider = new StubbedGraphicsProvider();
+            graphicsProvider.ProvideConsoleOutputHandleINativeCallsSizeFrameCharSets = (handle, calls, arg3, arg4) =>
+            {
+                graphicsProvided = true;
+                return graphicsProvider.Graphics;
+            };
+            using var sut = new ConControls.Controls.ConsoleWindow(api, controller, graphicsProvider);
+            var suti = (IControlContainer)sut;
+            sut.DefaultCursorSize.Should().Be(originalCursorSize);
+            suti.CursorSize.Should().Be(originalCursorSize);
+            graphicsProvided = false;
+            suti.CursorSize = alternativeCursorSize;
+            graphicsProvided.Should().BeTrue();
+            sut.DefaultCursorSize.Should().Be(alternativeCursorSize);
+
+            graphicsProvided = false;
+            suti.CursorSize = null;
+            graphicsProvided.Should().BeFalse();
+            sut.DefaultCursorSize.Should().Be(alternativeCursorSize);
+        }
+    }
+}

--- a/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultForegroundColor.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/ConsoleWindow/DefaultForegroundColor.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * (C) René Vogt
+ *
+ * Published under MIT license as described in the LICENSE.md file.
+ *
+ */
+
+#nullable enable
+
+using System;
+using ConControls.Controls;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+// ReSharper disable AccessToDisposedClosure
+
+namespace ConControlsTests.UnitTests.Controls.ConsoleWindow
+{
+    public partial class ConsoleWindowTests
+    {
+        [TestMethod]
+        public void DefaultForegroundColor_SetAndDrawn()
+        {
+            const ConsoleColor color = ConsoleColor.DarkMagenta;
+            var api = new StubbedNativeCalls();
+            using var controller = new StubbedConsoleController();
+            bool graphicsProvided = false;
+            var graphicsProvider = new StubbedGraphicsProvider();
+            graphicsProvider.ProvideConsoleOutputHandleINativeCallsSizeFrameCharSets = (handle, calls, arg3, arg4) =>
+            {
+                graphicsProvided = true;
+                return graphicsProvider.Graphics;
+            };
+            using var sut = new ConControls.Controls.ConsoleWindow(api, controller, graphicsProvider);
+            var suti = (IControlContainer)sut;
+            sut.DefaultForegroundColor.Should().Be(ConsoleColor.Gray);
+            suti.ForegroundColor.Should().Be(ConsoleColor.Gray);
+            graphicsProvided = false;
+            suti.ForegroundColor = color;
+            graphicsProvided.Should().BeTrue();
+            sut.DefaultForegroundColor.Should().Be(color);
+
+            graphicsProvided = false;
+            suti.ForegroundColor = null;
+            graphicsProvided.Should().BeFalse();
+            sut.DefaultForegroundColor.Should().Be(color);
+        }
+    }
+}

--- a/Sources/ConControlsTests/UnitTests/Controls/TextControl/BorderStyleChanged.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/TextControl/BorderStyleChanged.cs
@@ -24,7 +24,7 @@ namespace ConControlsTests.UnitTests.Controls.TextControl
                 Text = string.Empty.PadLeft(15, ' '),
                 Size = new Size(10, 10)
             };
-            sut.BorderStyle.Should().Be(BorderStyle.None);
+            sut.BorderStyle.Should().BeNull();
             sut.Caret = new Point(9, 0);
             sut.CursorPosition.Should().Be(new Point(9, 0));
             sut.BorderStyle = BorderStyle.Bold;

--- a/Sources/ConControlsTests/UnitTests/Controls/TextControl/ConstructAndDispose.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/TextControl/ConstructAndDispose.cs
@@ -18,15 +18,10 @@ namespace ConControlsTests.UnitTests.Controls.TextControl
         [TestMethod]
         public void ConstructAndDispsoed_EventsWired_EventsUnwired()
         {
-            const int cursorSize = 42;
-            using var window = new StubbedWindow
-            {
-                CursorSizeGet = () => cursorSize
-            };
+            using var window = new StubbedWindow();
             var textController = new StubbedConsoleTextController();
 
             using var sut = new StubbedTextControl(window, textController);
-            sut.CursorSize.Should().Be(cursorSize);
             sut.CursorVisible.Should().BeTrue();
             sut.CursorPosition.Should().Be(Point.Empty);
         }

--- a/Sources/ConControlsTests/UnitTests/Controls/TextControl/TabStop.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/TextControl/TabStop.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * (C) René Vogt
+ *
+ * Published under MIT license as described in the LICENSE.md file.
+ *
+ */
+
+#nullable enable
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ConControlsTests.UnitTests.Controls.TextControl
+{
+    public partial class TextControlTests
+    {
+        [TestMethod]
+        public void TabStop_InitiallyTrue()
+        {
+            using var stubbedWindow = new StubbedWindow();
+            var controller = new StubbedConsoleTextController();
+            using var sut = new StubbedTextControl(stubbedWindow, controller);
+            sut.TabStop.Should().BeTrue();
+            sut.TabStop = false;
+            sut.TabStop.Should().BeFalse();
+            sut.TabStop = true;
+            sut.TabStop.Should().BeTrue();
+        }
+    }
+}

--- a/Sources/ConControlsTests/UnitTests/StubbedWindow.cs
+++ b/Sources/ConControlsTests/UnitTests/StubbedWindow.cs
@@ -7,6 +7,7 @@
 
 #nullable enable
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using ConControls.Controls;
 using ConControls.Controls.Drawing.Fakes;
@@ -32,6 +33,11 @@ namespace ConControlsTests.UnitTests
             ControlsGet = () => Controls;
             EnabledGet = () => true;
             VisibleGet = () => true;
+            DefaultForegroundColorGet = () => ConsoleColor.Gray;
+            DefaultBackgroundColorGet = () => ConsoleColor.Black;
+            DefaultBorderColorGet = () => ConsoleColor.Yellow;
+            DefaultBorderStyleGet = () => BorderStyle.None;
+            DefaultCursorSizeGet = () => 1;
         }
     }
 }


### PR DESCRIPTION
Issue #1:
Changed the control behaviour to default the
- `BackgroundColor`
- `ForegroundColor`
- `BorderColor`
- `BorderStyle` and
- `CursorSize`

properties to the parent's properties or finally to the `ConsoleWindow.Default*` properties.

Issue #9:
Added a `TabStop` property that decides wether a control takes focus when tabbing through the window. This does not fully solve issue #9: The inheritance of text controls still needs reengineering in combination with issues #5 and #6.
