### PR TITLE
Introduced WrapMode enum and changed TextControl.Wrap to TextControl.WrapMode

### DIFF
--- a/Sources/ConControls/ConControls.xml
+++ b/Sources/ConControls/ConControls.xml
@@ -1721,7 +1721,7 @@
             Gets or sets the caret position.
             </summary>
         </member>
-        <member name="P:ConControls.Controls.TextControl.Wrap">
+        <member name="P:ConControls.Controls.TextControl.WrapMode">
             <summary>
             Gets or sets wether lines are wrapped or not.
             </summary>
@@ -1781,6 +1781,21 @@
         </member>
         <member name="P:ConControls.Controls.Text.ConsoleTextController.Width">
             <inheritdoc />
+        </member>
+        <member name="T:ConControls.Controls.Text.WrapMode">
+            <summary>
+            The wrap modes for controls derived from <see cref="T:ConControls.Controls.TextControl"/>.
+            </summary>
+        </member>
+        <member name="F:ConControls.Controls.Text.WrapMode.NoWrap">
+            <summary>
+            No wrapping at all.
+            </summary>
+        </member>
+        <member name="F:ConControls.Controls.Text.WrapMode.SimpleWrap">
+            <summary>
+            Simply wrap lines disregarding words or whitespaces etc.
+            </summary>
         </member>
         <member name="T:ConControls.Extensions.CoordinateExtensions">
             <summary>

--- a/Sources/ConControls/Controls/Text/ConsoleTextController.cs
+++ b/Sources/ConControls/Controls/Text/ConsoleTextController.cs
@@ -18,9 +18,9 @@ namespace ConControls.Controls.Text
         {
             internal List<string> BufferLines { get; } = new List<string>();
 
-            internal Line(string line, bool wrap, int width)
+            internal Line(string line, WrapMode wrapMode, int width)
             {
-                if (!wrap)
+                if (wrapMode == WrapMode.NoWrap)
                 {
                     BufferLines.Add(line);
                     return;
@@ -42,7 +42,7 @@ namespace ConControls.Controls.Text
         readonly List<Line> lines = new List<Line>();
         readonly List<string> allLines = new List<string>();
 
-        bool wrap;
+        WrapMode wrapMode;
         string text = string.Empty;
         int width = 1;
 
@@ -58,13 +58,13 @@ namespace ConControls.Controls.Text
             }
         }
 
-        public bool Wrap
+        public WrapMode WrapMode
         {
-            get => wrap;
+            get => wrapMode;
             set
             {
-                if (wrap == value) return;
-                wrap = value;
+                if (wrapMode == value) return;
+                wrapMode = value;
                 Refresh();
             }
         }
@@ -135,7 +135,7 @@ namespace ConControls.Controls.Text
             var unwrappedLines = content.Split(new[] { "\r\n" }, StringSplitOptions.None)
                                      .SelectMany(s => s.Split(new[] { "\n" }, StringSplitOptions.None))
                                      .ToArray();
-            var addedLines = unwrappedLines.Select(l => new Line(l, wrap, width)).ToArray();
+            var addedLines = unwrappedLines.Select(l => new Line(l, wrapMode, width)).ToArray();
             lines.AddRange(addedLines);
             allLines.AddRange(addedLines.SelectMany(l => l.BufferLines));
             MaxLineLength = allLines.Max(l => l.Length);
@@ -194,19 +194,19 @@ namespace ConControls.Controls.Text
         int NormalizeX(int x, int line)
         {
             int length = GetLineLength(line);
-            return Wrap && line < BufferLineCount - 1
+            return WrapMode != WrapMode.NoWrap && line < BufferLineCount - 1
                        ? Math.Min(x, Math.Min(length, width - 1))
                        : Math.Min(x, length);
         }
         bool ExceedsLine(int x, int y)
         {
             int length = GetLineLength(y);
-            return Wrap && y < BufferLineCount - 1 && x > length - 1 || x > length;
+            return WrapMode != WrapMode.NoWrap && y < BufferLineCount - 1 && x > length - 1 || x > length;
         }
         int EndOfLine(int line)
         {
             int length = GetLineLength(line);
-            return Wrap && line < BufferLineCount - 1 ? Math.Min(length, width - 1) : length;
+            return WrapMode != WrapMode.NoWrap && line < BufferLineCount - 1 ? Math.Min(length, width - 1) : length;
         }
     }
 }

--- a/Sources/ConControls/Controls/Text/IConsoleTextController.cs
+++ b/Sources/ConControls/Controls/Text/IConsoleTextController.cs
@@ -11,7 +11,7 @@ namespace ConControls.Controls.Text
 {
     interface IConsoleTextController
     {
-        bool Wrap { get; set; }
+        WrapMode WrapMode { get; set; }
         int Width { get; set; }
         int BufferLineCount { get; }
         int MaxLineLength { get; }

--- a/Sources/ConControls/Controls/Text/WrapMode.cs
+++ b/Sources/ConControls/Controls/Text/WrapMode.cs
@@ -1,0 +1,17 @@
+﻿namespace ConControls.Controls.Text
+{
+    /// <summary>
+    /// The wrap modes for controls derived from <see cref="TextControl"/>.
+    /// </summary>
+    public enum WrapMode
+    {
+        /// <summary>
+        /// No wrapping at all.
+        /// </summary>
+        NoWrap,
+        /// <summary>
+        /// Simply wrap lines disregarding words or whitespaces etc.
+        /// </summary>
+        SimpleWrap
+    }
+}

--- a/Sources/ConControls/Controls/TextControl.cs
+++ b/Sources/ConControls/Controls/TextControl.cs
@@ -139,18 +139,18 @@ namespace ConControls.Controls
         /// <summary>
         /// Gets or sets wether lines are wrapped or not.
         /// </summary>
-        public bool Wrap
+        public virtual WrapMode WrapMode
         {
             get
             {
-                lock(Window.SynchronizationLock) return textController.Wrap;
+                lock(Window.SynchronizationLock) return textController.WrapMode;
             }
             set
             {
                 lock (Window.SynchronizationLock)
                 {
-                    if (value == textController.Wrap) return;
-                    textController.Wrap= value;
+                    if (value == textController.WrapMode) return;
+                    textController.WrapMode = value;
                 }
             }
         }

--- a/Sources/ConControlsExamples/Examples/TextBlockExample.cs
+++ b/Sources/ConControlsExamples/Examples/TextBlockExample.cs
@@ -12,6 +12,7 @@ using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 using ConControls.Controls;
+using ConControls.Controls.Text;
 
 // ReSharper disable AccessToDisposedClosure
 
@@ -63,7 +64,7 @@ lines.";
                     BorderStyle = BorderStyle.None,
                     BackgroundColor = ConsoleColor.Blue,
                     ForegroundColor = ConsoleColor.White,
-                    Wrap = true
+                    WrapMode = WrapMode.SimpleWrap
                 };
                 var block3 = new TextBlock(window)
                 {
@@ -76,7 +77,7 @@ lines.";
                 {
                     Area = new Rectangle(12, 8, 10, 6),
                     BorderStyle = BorderStyle.SingleLined,
-                    Wrap = true,
+                    WrapMode = WrapMode.SimpleWrap,
                     BackgroundColor = ConsoleColor.Blue,
                     ForegroundColor = ConsoleColor.White
                 };

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/Append.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/Append.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System.Drawing;
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -21,7 +22,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true
+                WrapMode = WrapMode.SimpleWrap
             };
             sut.Append(string.Empty);
             sut.MaxLineLength.Should().Be(0);
@@ -33,7 +34,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Text = text
             };
 

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/Clear.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/Clear.cs
@@ -7,6 +7,7 @@
 
 #nullable enable
 
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -21,7 +22,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Text = text
             };
 

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/EndCaret.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/EndCaret.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System.Drawing;
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -21,7 +22,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = false
+                WrapMode = WrapMode.NoWrap
             };
             sut.EndCaret.Should().Be(Point.Empty);
         }
@@ -31,7 +32,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true
+                WrapMode = WrapMode.SimpleWrap
             };
             sut.EndCaret.Should().Be(Point.Empty);
         }
@@ -42,7 +43,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             {
                 Text = "Hello\nWorld",
                 Width = 5,
-                Wrap = false
+                WrapMode = WrapMode.NoWrap
             };
             sut.EndCaret.Should().Be(new Point(5, 1));
         }
@@ -53,7 +54,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             {
                 Text = "Hello\nWorld\n",
                 Width = 5,
-                Wrap = false
+                WrapMode = WrapMode.NoWrap
             };
             sut.EndCaret.Should().Be(new Point(0, 2));
         }
@@ -64,7 +65,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             {
                 Text = "Hello\nWor",
                 Width = 5,
-                Wrap = true
+                WrapMode = WrapMode.SimpleWrap
             };
             sut.EndCaret.Should().Be(new Point(3, 2));
         }
@@ -75,7 +76,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             {
                 Text = "HelloWorld\n",
                 Width = 5,
-                Wrap = true
+                WrapMode = WrapMode.SimpleWrap
             };
             sut.EndCaret.Should().Be(new Point(0, 3));
         }

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/MoveCaret.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/MoveCaret.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System.Drawing;
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -20,7 +21,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
         {
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
-                Wrap = false,
+                WrapMode = WrapMode.NoWrap,
                 Width = 5
             };
 
@@ -38,7 +39,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
         {
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Width = 5
             };
 
@@ -57,7 +58,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Text = "Hello\nWor",
-                Wrap = false,
+                WrapMode = WrapMode.NoWrap,
                 Width = 5
             };
 
@@ -83,7 +84,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Text = "Hello\nWorld!\n",
-                Wrap = false,
+                WrapMode = WrapMode.NoWrap,
                 Width = 5
             };
 
@@ -109,7 +110,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Text = "Hi\nWor",
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Width = 5
             };
 
@@ -134,7 +135,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Text = "Hi\nWorld",
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Width = 5
             };
 

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/MoveCaretPageDown.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/MoveCaretPageDown.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System.Drawing;
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -20,7 +21,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
         {
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
-                Wrap = false,
+                WrapMode = WrapMode.NoWrap,
                 Width = 5
             };
             sut.MoveCaretPageDown(Point.Empty, 5).Should().Be(Point.Empty);
@@ -31,7 +32,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
         {
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Width = 5
             };
             sut.MoveCaretPageDown(Point.Empty, 5).Should().Be(Point.Empty);
@@ -43,7 +44,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Text = "Line1\nLine2\nLongLine3\nLine4",
-                Wrap = false,
+                WrapMode = WrapMode.NoWrap,
                 Width = 5
             };
             sut.MoveCaretPageDown(Point.Empty, 5).Should().Be(new Point(0, 3));
@@ -57,7 +58,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Text = "Line1Line2L3\nLine4",
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Width = 5
             };
             sut.MoveCaretPageDown(Point.Empty, 5).Should().Be(new Point(0, 4));

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/MoveCaretPageUp.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/MoveCaretPageUp.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System.Drawing;
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -20,7 +21,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
         {
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
-                Wrap = false,
+                WrapMode = WrapMode.NoWrap,
                 Width = 5
             };
             sut.MoveCaretPageUp(Point.Empty, 5).Should().Be(Point.Empty);
@@ -31,7 +32,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
         {
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Width = 5
             };
             sut.MoveCaretPageUp(Point.Empty, 5).Should().Be(Point.Empty);
@@ -43,7 +44,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Text = "Line1\nLine2\nLine3\nLongLine4",
-                Wrap = false,
+                WrapMode = WrapMode.NoWrap,
                 Width = 5
             };
             sut.MoveCaretPageUp(Point.Empty, 5).Should().Be(Point.Empty);
@@ -57,7 +58,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Text = "Line1Line2L3\nLine4",
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Width = 5
             };
             sut.MoveCaretPageUp(Point.Empty, 5).Should().Be(Point.Empty);

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/TextProcessingTests.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/TextProcessingTests.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System.Drawing;
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -22,7 +23,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Text = text
             };
 
@@ -30,7 +31,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             sut.MaxLineLength.Should().Be(5);
             sut.Text.Should().Be(text);
             sut.Width.Should().Be(5);
-            sut.Wrap.Should().BeTrue();
+            sut.WrapMode.Should().Be(WrapMode.SimpleWrap);
             sut.GetLineLength(-1).Should().Be(0);
             sut.GetLineLength(0).Should().Be(5);
             sut.GetLineLength(1).Should().Be(5);
@@ -54,14 +55,14 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
                    '\0', '\0', '\0', '\0', '\0', '\0', '\0',
                    '2', '3', '4', '\0', '\0', '\0', '\0');
 
-            sut.Wrap = false;
+            sut.WrapMode = WrapMode.NoWrap;
             sut.Width = 4;
 
             sut.BufferLineCount.Should().Be(2);
             sut.MaxLineLength.Should().Be(10);
             sut.Text.Should().Be(text);
             sut.Width.Should().Be(4);
-            sut.Wrap.Should().BeFalse();
+            sut.WrapMode.Should().Be(WrapMode.NoWrap);
             sut.GetLineLength(-1).Should().Be(0);
             sut.GetLineLength(0).Should().Be(10);
             sut.GetLineLength(1).Should().Be(10);
@@ -80,7 +81,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Text = text
             };
             sut.GetCharacters(new Rectangle(Point.Empty, new Size(6, 4)))
@@ -98,7 +99,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Text = text
             };
             sut.GetCharacters(new Rectangle(Point.Empty, new Size(-1, 1)))

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/ValidateCaret.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/ValidateCaret.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System.Drawing;
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -21,7 +22,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Text = string.Empty
             };
 
@@ -45,7 +46,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Text = "0123456789\n0123456789"
             };
 
@@ -74,7 +75,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = false,
+                WrapMode = WrapMode.NoWrap,
                 Text = "0123456789\n0123456789"
             };
 
@@ -94,7 +95,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 5,
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Text = "0123456789\n0123456789"
             };
 

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/Width.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/Width.cs
@@ -7,6 +7,7 @@
 
 #nullable enable
 
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -33,7 +34,7 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
             var sut = new ConControls.Controls.Text.ConsoleTextController
             {
                 Width = 4,
-                Wrap = true,
+                WrapMode = WrapMode.SimpleWrap,
                 Text = text
             };
 

--- a/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/Wrap.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/Text/ConsoleTextController/Wrap.cs
@@ -7,6 +7,7 @@
 
 #nullable enable
 
+using ConControls.Controls.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -24,17 +25,17 @@ namespace ConControlsTests.UnitTests.Controls.Text.ConsoleTextController
                 Text = text
             };
 
-            sut.Wrap.Should().BeFalse();
+            sut.WrapMode.Should().Be(WrapMode.NoWrap);
             sut.BufferLineCount.Should().Be(2);
-            sut.Wrap = false;
-            sut.Wrap.Should().BeFalse();
+            sut.WrapMode = WrapMode.NoWrap;
+            sut.WrapMode.Should().Be(WrapMode.NoWrap);
             sut.BufferLineCount.Should().Be(2);
 
-            sut.Wrap = true;
-            sut.Wrap.Should().BeTrue();
+            sut.WrapMode = WrapMode.SimpleWrap;
+            sut.WrapMode.Should().Be(WrapMode.SimpleWrap);
             sut.BufferLineCount.Should().Be(7);
-            sut.Wrap = true;
-            sut.Wrap.Should().BeTrue();
+            sut.WrapMode = WrapMode.SimpleWrap;
+            sut.WrapMode.Should().Be(WrapMode.SimpleWrap);
             sut.BufferLineCount.Should().Be(7);
         }
     }

--- a/Sources/ConControlsTests/UnitTests/Controls/TextControl/Wrap.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/TextControl/Wrap.cs
@@ -9,6 +9,7 @@
 
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WrapMode = ConControls.Controls.Text.WrapMode;
 
 namespace ConControlsTests.UnitTests.Controls.TextControl
 {
@@ -18,27 +19,27 @@ namespace ConControlsTests.UnitTests.Controls.TextControl
         public void Wrap_GetControllers_Value()
         {
             using var stubbedWindow = new StubbedWindow();
-            bool wrap = false;
+            WrapMode wrap = WrapMode.NoWrap;
             var controller = new StubbedConsoleTextController
             {
-                WrapGet = () => wrap
+                WrapModeGet = () => wrap
             };
             using var sut = new StubbedTextControl(stubbedWindow, controller);
 
-            sut.Wrap.Should().BeFalse();
-            wrap = true;
-            sut.Wrap.Should().BeTrue();
+            sut.WrapMode.Should().Be(WrapMode.NoWrap);
+            wrap = WrapMode.SimpleWrap;
+            sut.WrapMode.Should().Be(WrapMode.SimpleWrap);
         }
         [TestMethod]
         public void Wrap_SetControllers_Value()
         {
             using var stubbedWindow = new StubbedWindow();
-            bool wrap = false;
+            WrapMode wrap = WrapMode.NoWrap;
             int called = 0;
             var controller = new StubbedConsoleTextController
             {
-                WrapGet = () => wrap,
-                WrapSetBoolean = b =>
+                WrapModeGet = () => wrap,
+                WrapModeSetWrapMode = b =>
                 {
                     called += 1;
                     wrap = b;
@@ -46,19 +47,19 @@ namespace ConControlsTests.UnitTests.Controls.TextControl
             };
             using var sut = new StubbedTextControl(stubbedWindow, controller);
 
-            sut.Wrap.Should().BeFalse();
-            sut.Wrap = true;
+            sut.WrapMode.Should().Be(WrapMode.NoWrap);
+            sut.WrapMode = WrapMode.SimpleWrap;
             called.Should().Be(1);
-            wrap.Should().BeTrue();
-            sut.Wrap = true;
+            wrap.Should().Be(WrapMode.SimpleWrap);
+            sut.WrapMode = WrapMode.SimpleWrap;
             called.Should().Be(1);
-            wrap.Should().BeTrue();
-            sut.Wrap = false;
+            wrap.Should().Be(WrapMode.SimpleWrap);
+            sut.WrapMode = WrapMode.NoWrap;
             called.Should().Be(2);
-            wrap.Should().BeFalse();
-            sut.Wrap = false;
+            wrap.Should().Be(WrapMode.NoWrap);
+            sut.WrapMode = WrapMode.NoWrap;
             called.Should().Be(2);
-            wrap.Should().BeFalse();
+            wrap.Should().Be(WrapMode.NoWrap);
         }
     }
 }


### PR DESCRIPTION
The old `bool Wrap` property of the `TextControl` has been replaced by a `WrapMode WrapMode` property of the new enum type `WrapMode`. This is a precondition for #19.

Fixes #18 