### PR TITLE
Fixed wrong CursorVisible implementation in TextBlock.

### DIFF
--- a/Sources/ConControls/ConControls.xml
+++ b/Sources/ConControls/ConControls.xml
@@ -1820,6 +1820,11 @@
             Raised when the <see cref="P:ConControls.Controls.TextControl.CanFocus"/> property has been changed.
             </summary>
         </member>
+        <member name="P:ConControls.Controls.TextControl.CaretVisible">
+            <summary>
+            Gets wether the caret is inside the currently displayed area.
+            </summary>
+        </member>
         <member name="P:ConControls.Controls.TextControl.CanEdit">
             <summary>
             Gets or sets wether this <see cref="T:ConControls.Controls.TextControl"/> is read-only or can be edited.

--- a/Sources/ConControls/Controls/ConsoleWindow.cs
+++ b/Sources/ConControls/Controls/ConsoleWindow.cs
@@ -188,9 +188,10 @@ namespace ConControls.Controls
                         oldFocused.Focused = false;
                     }
                     focusedControl = value;
+                    UpdateCursor();
                     if (focusedControl == null) return;
                     focusedControl.Focused = true;
-                    api.SetCursorInfo(consoleController.OutputHandle, focusedControl.CursorVisible, GetCursorSizeForControl(focusedControl), focusedControl.PointToConsole(focusedControl.CursorPosition));
+//                    api.SetCursorInfo(consoleController.OutputHandle, focusedControl.CursorVisible, GetCursorSizeForControl(focusedControl), focusedControl.PointToConsole(focusedControl.CursorPosition));
                     focusedControl.CursorPositionChanged += OnFocusedControlCursorChanged;
                     focusedControl.CursorSizeChanged += OnFocusedControlCursorChanged;
                     focusedControl.CursorVisibleChanged += OnFocusedControlCursorChanged;

--- a/Sources/ConControls/Controls/TextBlock.cs
+++ b/Sources/ConControls/Controls/TextBlock.cs
@@ -41,7 +41,7 @@ namespace ConControls.Controls
         /// <inheritdoc />
         public override bool CursorVisible
         {
-            get => base.CursorVisible || initCursorVisible;
+            get => (base.CursorVisible || initCursorVisible) && CaretVisible;
             set
             {
                 initCursorVisible = false;

--- a/Sources/ConControls/Controls/TextControl.cs
+++ b/Sources/ConControls/Controls/TextControl.cs
@@ -22,7 +22,7 @@ namespace ConControls.Controls
     {
         readonly IConsoleTextController textController;
 
-        bool caretVisible, canFocus;
+        bool canFocus;
         Point scroll;
         Point caret;
 
@@ -34,6 +34,15 @@ namespace ConControls.Controls
         /// Raised when the <see cref="CanFocus"/> property has been changed.
         /// </summary>
         public event EventHandler? CanFocusChanged;
+
+        /// <summary>
+        /// Gets wether the caret is inside the currently displayed area.
+        /// </summary>
+        public virtual bool CaretVisible
+        {
+            get;
+            private set;
+        }
 
         /// <summary>
         /// Gets or sets wether this <see cref="TextControl"/> is read-only or can be edited.
@@ -91,7 +100,7 @@ namespace ConControls.Controls
         /// <inheritdoc />
         public override bool CursorVisible
         {
-            get => base.CursorVisible && caretVisible;
+            get => base.CursorVisible && CaretVisible;
             set => base.CursorVisible = value;
         }
 
@@ -399,15 +408,15 @@ namespace ConControls.Controls
             if (clientArea.Contains(caretPosition))
             {
                 CursorPosition = caretPosition;
-                if (!caretVisible)
+                if (!CaretVisible)
                 {
-                    caretVisible = true;
+                    CaretVisible = true;
                     OnCursorVisibleChanged();
                 }
             }
-            else if (caretVisible)
+            else if (CaretVisible)
             {
-                caretVisible = false;
+                CaretVisible = false;
                 OnCursorVisibleChanged();
             }
         }

--- a/Sources/ConControlsTests/UnitTests/Controls/TextBlock/CursorVisible.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/TextBlock/CursorVisible.cs
@@ -7,8 +7,12 @@
 
 #nullable enable
 
+using System;
 using System.Drawing;
+using System.Linq;
+using ConControls.ConsoleApi;
 using ConControls.Extensions;
+using ConControls.WindowsApi.Types;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -26,6 +30,23 @@ namespace ConControlsTests.UnitTests.Controls.TextBlock
                 Size = new Size(10, 10)
             };
             sut.CursorVisible.Should().BeTrue();
+        }
+        [TestMethod]
+        public void CursorVisible_CaretOutside_False()
+        {
+            using var stubbedWindow = new StubbedWindow();
+            var textController = new StubbedConsoleTextController
+            {
+                ValidateCaretPoint = p => p
+            };
+            using var sut = new ConControls.Controls.TextBlock(stubbedWindow, textController)
+            {
+                Size = new Size(10, 10)
+            };
+            sut.CursorVisible.Should().BeTrue();
+            sut.Caret = (11, 11).Pt();
+            sut.CaretVisible.Should().BeFalse();
+            sut.CursorVisible.Should().BeFalse();
         }
         [TestMethod]
         public void CursorVisible_Set_EventOnlyOnChange()
@@ -53,6 +74,41 @@ namespace ConControlsTests.UnitTests.Controls.TextBlock
             sut.CursorVisible = true;
             sut.CursorVisible.Should().BeTrue();
             raised.Should().Be(3);
+        }
+        [TestMethod]
+        public void CursorVisible_IntegrationTest_RespectsCaretVisibility()
+        {
+            var api = new StubbedNativeCalls();
+            using var controller = new StubbedConsoleController();
+            string text = string.Join(Environment.NewLine, Enumerable.Repeat("12345678901234567890", 40));
+            using var window = new ConControls.Controls.ConsoleWindow(api, controller, new StubbedGraphicsProvider());
+            using var sut = new ConControls.Controls.TextBlock(window)
+            {
+                Area = (5, 5, 10, 10).Rect(),
+                Parent = window,
+                Text = text,
+                Caret = (5, 0).Pt(),
+                CanFocus = true,
+                Focused = true
+            };
+
+            sut.Caret.Should().Be((5, 0).Pt());
+            sut.CursorVisible.Should().BeTrue();
+            sut.CursorPosition.Should().Be((5, 0).Pt());
+            var e = new ConsoleMouseEventArgs(new MOUSE_EVENT_RECORD
+            {
+                EventFlags = MouseEventFlags.Wheeled,
+                MousePosition = new COORD(5, 5),
+                Scroll = -120
+            });
+
+            bool setCorrectly = false;
+            api.SetCursorInfoConsoleOutputHandleBooleanInt32Point = (handle, visible, size, location) => setCorrectly = !visible;
+            controller.MouseEventEvent(controller, e);
+            setCorrectly.Should().BeTrue();
+            sut.Scroll.Should().Be((0, 1).Pt());
+            sut.CursorVisible.Should().BeFalse();
+            sut.Caret.Should().Be((5, 0).Pt());
         }
     }
 }

--- a/Sources/ConControlsTests/UnitTests/Controls/TextControl/OnMouseScroll.cs
+++ b/Sources/ConControlsTests/UnitTests/Controls/TextControl/OnMouseScroll.cs
@@ -403,24 +403,39 @@ namespace ConControlsTests.UnitTests.Controls.TextControl
             using var stubbedWindow = new StubbedWindow();
             var stubbedController = new StubbedConsoleTextController
             {
-                BufferLineCountGet = () => 20
+                BufferLineCountGet = () => 20,
+                GetLineLengthInt32 = _ => 20,
+                MaxLineLengthGet = () => 20,
+                ValidateCaretPoint = p => p
             };
             using var sut = new StubbedTextControl(stubbedWindow, stubbedController)
             {
                 Area = (5, 5, 10, 10).Rect(),
                 Parent = stubbedWindow,
-                Scroll = (0, 5).Pt()
+                Scroll = (0, 5).Pt(),
+                Caret = (5, 6).Pt(),
+                CursorVisible = true,
+                CanFocus = true,
+                Focused = true
             };
 
             sut.Scroll.Should().Be((0, 5).Pt());
+            sut.Caret.Should().Be((5, 6).Pt());
+            sut.CursorVisible.Should().BeTrue();
+            sut.CursorPosition.Should().Be((5, 1).Pt());
             var e = new MouseEventArgs(new ConsoleMouseEventArgs(new MOUSE_EVENT_RECORD
             {
                 EventFlags = MouseEventFlags.Wheeled,
                 MousePosition = new COORD(5, 5),
                 Scroll = -360
             }));
+            bool changed = false;
+            sut.CursorVisibleChanged += (sender, e1) => changed = true;
             stubbedWindow.MouseEventEvent(stubbedWindow, e);
             sut.Scroll.Should().Be((0, 8).Pt());
+            sut.CursorVisible.Should().BeFalse();
+            changed.Should().BeTrue();
+            sut.Caret.Should().Be((5, 6).Pt());
             e.Handled.Should().BeTrue();
         }
         [TestMethod]


### PR DESCRIPTION
When overwriiting `CursorVisible` in `TextBlock`, the initial value hid the fact that `caretVisible` was `false`.  
`CaretVisible` is now a public virtual getter (but private setter) in `TextControl`, so we can check this in derived classes, too, without having to recalculate.

Fixes #20 